### PR TITLE
Add Maskmail to Commercial Email Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ A curated list of awesome resources related to enhancing your enterprise Email S
 * [Open Source DMARC Report Analyzer](https://github.com/userjack6880/Open-DMARC-Analyzer) - Open Source DMARC Report Analyzer. 
 
 ### Commercial Email Security Tools
+* [Maskmail](https://maskmail.io) - Privacy-first email mask service. Create one mask per service, forward what matters, and disable abused masks instantly.
+
 ### Open Source Email Security Tools
 * [DMARC Record Analyzer](https://github.com/cisagov/trustymail) - CISA SPF/DMARC Record Analyzer.
 * [DMARC Report Parser](https://github.com/domainaware/parsedmarc) - DMARC Report Parser.


### PR DESCRIPTION
Adds [Maskmail](https://maskmail.io) under **Tools > Commercial Email Security Tools** (currently empty).

Maskmail is a privacy-first email mask service. Users create a unique mask per service or signup, forward what matters to a hidden inbox, and disable any abused mask instantly. This reduces phishing and credential-stuffing exposure by making the email address per service unique and revocable, complementing the SPF/DKIM/DMARC controls already covered in this list.

### Affiliation
I work on Maskmail.

Happy to move it to a different section if you prefer, or add a dedicated subsection (e.g. "Email Aliasing / Masking") if it's a better fit.