### PR TITLE
Add notspoofed SPF/DKIM/DMARC checker and header analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A curated list of awesome resources related to enhancing your enterprise Email S
 * [Microsoft MHA](https://mha.azurewebsites.net/) - Microsoft Email Header Analysis.
 * [MxToolBox MHA](https://mxtoolbox.com/EmailHeaders.aspx) - MxToolBox Email Header Analyzer.
 * [CyberDefenders MHA](https://github.com/cyberdefenders/email-header-analyzer) - Excellent Email Header Analyzer that can be deployed locally.
+* [notspoofed Header Analyzer](https://notspoofed.com/headers) - Browser-based email header analyzer showing the delivery path, hop delays, and why DMARC passed or failed. Runs entirely in the browser, nothing is uploaded. ([Source Code](https://github.com/josepollman-png/notspoofed)) `MIT`
 
 ### DMARC Reports Analysis
 * [MxToolBox DMARC Report Analyzer](https://mxtoolbox.com/DmarcReportAnalyzer.aspx) - MxToolBox DMARC Report Analyzer.
@@ -76,6 +77,7 @@ A curated list of awesome resources related to enhancing your enterprise Email S
 * [DMARC Report Parser](https://github.com/domainaware/parsedmarc) - DMARC Report Parser.
 * [DMARC Report Parser](https://github.com/emalderson/ThePhish) - ThePhish is an automated phishing email analysis tool based on TheHive, Cortex and MISP.
 * [NetworkWhois Email Validator](https://networkwhois.com/email-validator) - Validate MX, SPF, DKIM, DMARC and get a score with actionable recommendations.
+* [notspoofed](https://notspoofed.com) - Counts SPF DNS lookups against the ten-lookup limit and generates a corrected record, verifies DKIM selector hits are genuine signing keys rather than wildcard DNS responses, and checks whether external DMARC report addresses are authorised to receive reports. ([Source Code](https://github.com/josepollman-png/notspoofed)) `MIT`
 
 ## Reading
 ### Books


### PR DESCRIPTION
Two entries, both MIT licensed and free with no signup.

Header analyzer, added alongside the existing Microsoft and MxToolBox entries. It differs from those in running entirely in the browser, so headers are never uploaded anywhere.

Domain checker, added next to NetworkWhois Email Validator as the closest existing entry. Three things it does that most checkers don't: it walks the full include chain and follows redirect= when counting SPF lookups, then outputs a corrected record that flattens only what it must; it verifies a DKIM selector hit is a genuine signing key rather than a wildcard DNS response; and it checks RFC 7489 section 7.1 authorisation for external DMARC report addresses, which is a common reason aggregate reports silently never arrive.

Happy to move either entry if you'd prefer a different section.