### PR TITLE
Add DMARC Analyzer to DMARC Reports Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of awesome resources related to enhancing your enterprise Email S
 ### DMARC Reports Analysis
 * [MxToolBox DMARC Report Analyzer](https://mxtoolbox.com/DmarcReportAnalyzer.aspx) - MxToolBox DMARC Report Analyzer.
 * [Open Source DMARC Report Analyzer](https://github.com/userjack6880/Open-DMARC-Analyzer) - Open Source DMARC Report Analyzer. 
+* [DMARC Analyzer](https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp) - Open-source, self-hosted DMARC aggregate report analyzer with per-client dashboards.
 
 ### Commercial Email Security Tools
 ### Open Source Email Security Tools


### PR DESCRIPTION
Adding [DMARC Analyzer](https://github.com/dmarc-analyzer-net/DmarcAnalyzerApp)
to **DMARC Reports Analysis**.

**What it is:** a self-hosted application that collects DMARC aggregate reports
from a mailbox, parses them, and charts them per domain. Domains are grouped per
client with per-client access, so one instance can cover many organisations —
useful for MSPs and agencies. It also ingests MTA-STS and TLS-RPT reports.

- Apache-2.0, source on GitHub
- Actively developed, currently 0.9.0
- Docker image, Compose file and a Helm chart on Artifact Hub
- Report data stays on the operator's own infrastructure

The entry follows the section's existing format. Happy to reword or relocate it
if you would prefer it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)